### PR TITLE
Remove content from follow navigation link

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -61,9 +61,7 @@ export default function Home() {
             <a href="/about" className="hover:text-black transition-colors">about</a>
             <a href="/writing" className="hover:text-black transition-colors">writing</a>
             <a href="/bookmarks" className="hover:text-black transition-colors">bookmarks</a>
-            <a href="/follow" className="hover:text-black transition-colors flex items-center">
-              follow <span className="ml-1">↗</span>
-            </a>
+            <a href="/follow" className="hover:text-black transition-colors flex items-center" />
             <a href="/code" className="hover:text-black transition-colors flex items-center">
               code <span className="ml-1">↗</span>
             </a>


### PR DESCRIPTION
Remove the text content and arrow icon from the follow navigation link.

The follow link now renders as an empty anchor element while maintaining its CSS classes and href attribute.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/de5d228221d446f294df6d4b51018195/vortex-forge)

👀 [Preview Link](https://de5d228221d446f294df6d4b51018195-vortex-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>de5d228221d446f294df6d4b51018195</projectId>-->
<!--<branchName>vortex-forge</branchName>-->